### PR TITLE
Remove fastrtps examples from installation.

### DIFF
--- a/debian/rules.em
+++ b/debian/rules.em
@@ -56,3 +56,4 @@ override_dh_auto_install:
 	# set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_install
+	rm -r $(CURDIR)/debian/@(Package)/@(InstallationPrefix)/examples


### PR DESCRIPTION
Fixes #3.

After merging a debinc release of fastrtps is needed to deploy it.