### PR TITLE
Skip example installation cmake

### DIFF
--- a/debian/rules.em
+++ b/debian/rules.em
@@ -26,7 +26,7 @@ override_dh_auto_configure:
 	# in the install tree that was dropped by catkin, and source it.  It will
 	# set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
-	dh_auto_configure -- -DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" -DSECURITY=ON
+	dh_auto_configure -- -DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" -DINSTALL_EXAMPLES=OFF -DSECURITY=ON
 
 override_dh_auto_build:
 	# In case we're installing to a non-standard location, look for a setup.sh

--- a/debian/rules.em
+++ b/debian/rules.em
@@ -56,4 +56,3 @@ override_dh_auto_install:
 	# set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_install
-	rm -r $(CURDIR)/debian/@(Package)/@(InstallationPrefix)/examples


### PR DESCRIPTION
This reverts #4 and uses the CMake option introduced in https://github.com/eProsima/Fast-RTPS/pull/238 instead