### PR TITLE
Update eloquent devel_branch to match rosdistro source entry

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -111,7 +111,7 @@ tracks:
       -i :{release_inc} --os-name debian --os-not-required
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc}
-    devel_branch: eloquent
+    devel_branch: ros2-eloquent
     last_release: 6bfd02a1b468218858dc0365afcc8ca892c4027f
     last_version: 1.9.3
     name: fastrtps


### PR DESCRIPTION
This PR from an automated script updates the devel_branch for eloquent to match the source branch as specified in https://github.com/ros/rosdistro/eloquent/distribution.yaml .

Links to https://github.com/ros2/ros2/issues/963 .
