### PR TITLE
Set CMake flags for Fast-RTPS

### DIFF
--- a/rpm/template.spec.em
+++ b/rpm/template.spec.em
@@ -46,6 +46,8 @@ mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
     -DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
     -DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
     -DSETUPTOOLS_DEB_LAYOUT=OFF \
+    -DINSTALL_EXAMPLES=OFF \
+    -DSECURITY=ON \
     ..
 
 %make_build


### PR DESCRIPTION
Debian counterpart: https://github.com/ros2-gbp/fastrtps-release/blob/patches/debian/eloquent/fastrtps/0001-Set-CMake-flags-for-Fast-RTPS.patch

**NOTE**: If this PR is squash-merged, be sure to drop the PR number from the end of the commit message, or every time this patch is re-applied by Bloom, it will be back-linked from this PR.