### PR TITLE
Make sure to set SECURITY=ON when building Fast-RTPS.

### DIFF
--- a/debian/rules.em
+++ b/debian/rules.em
@@ -28,7 +28,9 @@ override_dh_auto_configure:
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_configure -- \
 		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
-		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)"
+		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
+		-DINSTALL_EXAMPLES=OFF \
+		-DSECURITY=ON
 
 override_dh_auto_build:
 	# In case we're installing to a non-standard location, look for a setup.sh


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix the problem reported in https://github.com/ros2/sros2/issues/252 for Foxy.