### PR TITLE
Bundle Asio on RHEL 8

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,8 +7,6 @@
   <maintainer email="stevenragnarok@osrfoundation.org">Steven! Ragnarök</maintainer>
   <license>Apache License 2.0</license>
 
-  <build_depend>asio</build_depend>
-
   <build_export_depend>libssl-dev</build_export_depend>
 
   <exec_depend>libssl-dev</exec_depend>

--- a/rpm/ros-rolling-fastrtps.spec
+++ b/rpm/ros-rolling-fastrtps.spec
@@ -18,7 +18,6 @@ Requires:       ros-rolling-fastcdr
 Requires:       ros-rolling-foonathan-memory-vendor
 Requires:       tinyxml2-devel
 Requires:       ros-rolling-ros-workspace
-BuildRequires:  asio-devel
 BuildRequires:  cmake3
 BuildRequires:  ros-rolling-fastcdr
 BuildRequires:  ros-rolling-foonathan-memory-vendor
@@ -51,6 +50,7 @@ mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
     -DSETUPTOOLS_DEB_LAYOUT=OFF \
     -DINSTALL_EXAMPLES=OFF \
     -DSECURITY=ON \
+    -DTHIRDPARTY_Asio=ON \
     ..
 
 %make_build


### PR DESCRIPTION
Asio is not currently available for RHEL 8, but it appears that Fast-DDS is able to bundle it. Rather than introduce an Asio package to the bootstrap repository just for this package, we can flip this flag to bundle it.

Here are the docs on this flag in Fast-DDS: https://github.com/eProsima/Fast-DDS/blob/master/cmake/common/eprosima_libraries.cmake

This change should be **fast-forward** merged after review.