### PR TITLE
Add an explicit build dependency on libssl-dev

### DIFF
--- a/ros2/package.xml
+++ b/ros2/package.xml
@@ -8,6 +8,7 @@
   <license>Apache License 2.0</license>
 
   <build_depend>asio</build_depend>
+  <build_depend>libssl-dev</build_depend>
 
   <build_export_depend>libssl-dev</build_export_depend>
 


### PR DESCRIPTION
This dependency is necessary for building with security enabled. It is typically a runtime dependency of libasio-dev, which is why this hasn't been a problem for the debs.