### PR TITLE
Add a patch directory for 'rolling'

### DIFF
--- a/rolling/package.xml
+++ b/rolling/package.xml
@@ -8,12 +8,14 @@
   <license>Apache License 2.0</license>
 
   <build_depend>asio</build_depend>
+  <build_depend>libssl-dev</build_depend>
 
   <build_export_depend>libssl-dev</build_export_depend>
 
   <exec_depend>libssl-dev</exec_depend>
 
   <depend>fastcdr</depend>
+  <depend>foonathan_memory_vendor</depend>
   <depend>tinyxml2</depend>
 
   <buildtool_depend>cmake</buildtool_depend>

--- a/ros2/package.xml
+++ b/ros2/package.xml
@@ -15,6 +15,7 @@
   <exec_depend>libssl-dev</exec_depend>
 
   <depend>fastcdr</depend>
+  <depend>foonathan_memory_vendor</depend>
   <depend>tinyxml2</depend>
 
   <buildtool_depend>cmake</buildtool_depend>

--- a/ros2/package.xml
+++ b/ros2/package.xml
@@ -15,7 +15,6 @@
   <exec_depend>libssl-dev</exec_depend>
 
   <depend>fastcdr</depend>
-  <depend>foonathan_memory_vendor</depend>
   <depend>tinyxml2</depend>
 
   <buildtool_depend>cmake</buildtool_depend>

--- a/tracks.yaml
+++ b/tracks.yaml
@@ -219,7 +219,7 @@ tracks:
     last_release: v2.0.0
     last_version: 2.0.0
     name: fastrtps
-    patches: foxy
+    patches: ros2
     release_inc: '6'
     release_repo_url: https://github.com/ros2-gbp/fastrtps-release.git
     release_tag: v:{version}

--- a/tracks.yaml
+++ b/tracks.yaml
@@ -219,7 +219,7 @@ tracks:
     last_release: v2.0.0
     last_version: 2.0.0
     name: fastrtps
-    patches: foxy
+    patches: rolling
     release_inc: '6'
     release_repo_url: https://github.com/ros2-gbp/fastrtps-release.git
     release_tag: v:{version}

--- a/tracks.yaml
+++ b/tracks.yaml
@@ -219,7 +219,7 @@ tracks:
     last_release: v2.0.0
     last_version: 2.0.0
     name: fastrtps
-    patches: ros2
+    patches: foxy
     release_inc: '6'
     release_repo_url: https://github.com/ros2-gbp/fastrtps-release.git
     release_tag: v:{version}


### PR DESCRIPTION
It looks like 'rolling' was using the 'foxy' patch directory. This change switches it to 'ros2', and grabs the missing update to 'foxy' to make the manifests the same.