### PR TITLE
Set CMake flags for Fast-RTPS.

### DIFF
--- a/debian/rules.em
+++ b/debian/rules.em
@@ -31,7 +31,9 @@ override_dh_auto_configure:
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_configure -- \
 		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
-		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)"
+		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
+		-DINSTALL_EXAMPLES=OFF \
+		-DSECURITY=ON
 
 override_dh_auto_build:
 	# In case we're installing to a non-standard location, look for a setup.sh


### PR DESCRIPTION
Restore patches dropped during Rolling migration https://github.com/ros/rosdistro/issues/32128